### PR TITLE
add group in config.xml and fix payment group

### DIFF
--- a/Paymee/Pix/etc/config.xml
+++ b/Paymee/Pix/etc/config.xml
@@ -26,6 +26,7 @@
                 <debugReplaceKeys>MERCHANT_KEY</debugReplaceKeys>
                 <paymentInfoKeys>FRAUD_MSG_LIST</paymentInfoKeys>
                 <privateInfoKeys>FRAUD_MSG_LIST</privateInfoKeys>
+                <group>paymee_group</group>
             </paymeepix>
         </payment>
     </default>

--- a/Paymee/Pix/etc/payment.xml
+++ b/Paymee/Pix/etc/payment.xml
@@ -2,8 +2,8 @@
 <payment xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Payment:etc/payment.xsd">
     <groups>
-        <group id="paymeepix_group">
-            <label>Pix</label>
+        <group id="paymee_group">
+            <label>PayMee</label>
         </group>
     </groups>
     <methods>

--- a/Paymee/Transferencia/etc/config.xml
+++ b/Paymee/Transferencia/etc/config.xml
@@ -26,6 +26,7 @@
                 <debugReplaceKeys>MERCHANT_KEY</debugReplaceKeys>
                 <paymentInfoKeys>FRAUD_MSG_LIST</paymentInfoKeys>
                 <privateInfoKeys>FRAUD_MSG_LIST</privateInfoKeys>
+                <group>paymee_group</group>
             </paymee>
         </payment>
     </default>

--- a/Paymee/Transferencia/etc/payment.xml
+++ b/Paymee/Transferencia/etc/payment.xml
@@ -3,7 +3,7 @@
          xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Payment:etc/payment.xsd">
     <groups>
         <group id="paymee_group">
-            <label>Transferencia</label>
+            <label>PayMee</label>
         </group>
     </groups>
     <methods>


### PR DESCRIPTION
Boa tarde. Estou implementando o PayMee na plataforma magento 2 na empresa que trabalho. Tive um problema na visualização do pedido no painel e enviei um email. Vi que vocês subiram os arquivos que estavam gerando o erro, então, resolveu, mas começou a dar outro problema também na visualização do pedido (com status processing), pois tem a parte de transações que ele monta o array com os métodos de pagamento, aí ele tava tentando montar e tava lançando essa exceção a seguir, talvez não tenha dado no ambiente de vocês pela versão do magento/php.
![image](https://user-images.githubusercontent.com/46428931/126381642-55737d4d-fba8-4e43-83d5-a6337988140e.png)

Analisando com a nossa equipe, vimos que faltou adicionar o group no config.xml dos módulos (ex: <group>paymee_group</group>), e para ficar melhor, colocamos o mesmo grupo nos dois módulos, pois dessa forma aparece os métodos (Pix e Transferência) dentro do grupo da PayMee, como na imagem abaixo:

![image](https://user-images.githubusercontent.com/46428931/126383758-efe4570f-b637-45e2-8893-0ec992e936cd.png)
