### PR TITLE
Fix error when updating order status on order view page

### DIFF
--- a/Paymee/Pix/Observer/SavePixInfoToOrderObserver.php
+++ b/Paymee/Pix/Observer/SavePixInfoToOrderObserver.php
@@ -59,8 +59,9 @@ class SavePixInfoToOrderObserver implements ObserverInterface {
 
         $this->logger->debug('Chamou paymee pix integration');
 
-        $inputParams = $this->_inputParamsResolver->resolve();
-        if($this->_state->getAreaCode() != \Magento\Framework\App\Area::AREA_ADMINHTML){
+        if ($this->_state->getAreaCode() != \Magento\Framework\App\Area::AREA_ADMINHTML) {
+            $inputParams = $this->_inputParamsResolver->resolve();
+
             foreach ($inputParams as $inputParam) {
                 if ($inputParam instanceof \Magento\Quote\Model\Quote\Payment) {
                     

--- a/Paymee/Transferencia/Observer/SaveBankInfoToOrderObserver.php
+++ b/Paymee/Transferencia/Observer/SaveBankInfoToOrderObserver.php
@@ -99,8 +99,9 @@ class SaveBankInfoToOrderObserver implements ObserverInterface {
     }
 
     public function execute(EventObserver $observer) {
-        $inputParams = $this->_inputParamsResolver->resolve();
-        if($this->_state->getAreaCode() != \Magento\Framework\App\Area::AREA_ADMINHTML){
+        if ($this->_state->getAreaCode() != \Magento\Framework\App\Area::AREA_ADMINHTML) {
+            $inputParams = $this->_inputParamsResolver->resolve();
+
             foreach ($inputParams as $inputParam) {
         
                 


### PR DESCRIPTION
Ao alterar um status do pedido dentro da página dele, é criado o log no histórico mas não altera o status. Debugando vi que tem dois observers da PayMee que estão lançando esse erro, nessa linha `$inputParams = $this->_inputParamsResolver->resolve();`. Acontece pois está na área adminhtml e ele tenta encontrar a rota de salvar o pedido nas rotas da API, então só colocando essa atribuição dentro do IF já resolve.

![image](https://user-images.githubusercontent.com/46428931/127388226-0721fbb7-e183-461e-88bb-fdb7662186d1.png)
